### PR TITLE
Support passing another view to display the tooltip into

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ You can use these directions :
 
     .Top, .Left, .Right, .Bottom, .TopLeft, .TopRight, .BottomLeft, .BottomRight
 
+If you want to display the tooltip into another view than the one you are attaching it to (like a parent to avoid your tooltip to be clipped), you can pass it as the second parameter when setting it to your view:    
+
+    myView.setTooltip(ZGTooltipView(direction: .Top, text: "Lorem ipsum dolor sit amet"), displayInView: myView.superview)
 
 ## Requirements
 

--- a/ZGTooltipView/Classes/ZGTooltipView.swift
+++ b/ZGTooltipView/Classes/ZGTooltipView.swift
@@ -54,7 +54,12 @@ public extension UIView {
             self.removeGestureRecognizer(gesture)
         }
         
-        tooltipView?.dismiss(remove:true)
+        tooltipView?.dismiss(remove: true)
+        
+        // Reset all variables
+        tooltipView = nil
+        tooltipDisplayView = nil
+        tooltipTapGesture = nil
     }
     
     public func showTooltip() {
@@ -63,14 +68,14 @@ public extension UIView {
         }
     }
     
-    public func dismissTooltip(remove:Bool = false) {
-        tooltipView?.dismiss(remove:remove)
+    public func dismissTooltip() {
+        tooltipView?.dismiss(remove: false)
     }
     
     @objc fileprivate func tooltipGestureHandler(_ gesture:UIGestureRecognizer) {
         
         if let tooltipView = tooltipView {
-            tooltipView.isVisible ? dismissTooltip(remove:false) : showTooltip()
+            tooltipView.isVisible ? dismissTooltip() : showTooltip()
         }
     }
     


### PR DESCRIPTION
This PR contains:
- a new `displayInView` parameter to the `setTooltip` method that can be used to pass the view you want to display your tooltip into.
- Clarify the `dismiss` and `remove` methods: Dismiss only dismiss the tooltip without removing it, remove actually removes it. Also add some variables clean into the remove method.